### PR TITLE
Widen dependencies for GHC 9.4

### DIFF
--- a/melf.cabal
+++ b/melf.cabal
@@ -18,7 +18,7 @@ license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.4
+    GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.4, GHC == 9.4.4
 extra-doc-files:
     ChangeLog.md
     README.md
@@ -75,10 +75,10 @@ library
     , binary >=0.8.7 && <0.9
     , bytestring >=0.10.10 && <0.12
     , exceptions >=0.10.4 && <0.11
-    , lens >=5.0.1 && <5.2
+    , lens >=5.0.1 && <5.3
     , mtl >=2.2.2 && <2.3
     , prettyprinter >=1.7.0 && <1.8
-    , template-haskell >=2.15 && <2.19
+    , template-haskell >=2.15 && <2.20
   if impl(ghc >= 9.0)
     build-depends:
         singletons >=3.0.1 && <3.1

--- a/package.yaml
+++ b/package.yaml
@@ -10,7 +10,7 @@ license: BSD3
 homepage: https://github.com/aleksey-makarov/melf
 dependencies:
     - base >=4.13 && <5.0
-tested-with: GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.4
+tested-with: GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.4, GHC == 9.4.4
 ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wno-redundant-constraints
 extra-doc-files:
     - ChangeLog.md
@@ -31,10 +31,10 @@ library:
     - binary        >= 0.8.7 && < 0.9
     - bytestring    >= 0.10.10 && < 0.12
     - exceptions    >= 0.10.4 && < 0.11
-    - lens          >= 5.0.1 && < 5.2
+    - lens          >= 5.0.1 && < 5.3
     - mtl           >= 2.2.2 && < 2.3
     - prettyprinter >= 1.7.0 && < 1.8
-    - template-haskell >= 2.15 && < 2.19
+    - template-haskell >= 2.15 && < 2.20
   source-dirs: src
   other-modules:
     - Data.Elf.Constants.TH


### PR DESCRIPTION
Hello,

Thanks for writing this library, it is very useful to me! While updating my GHC compiler toolchain to GHC 9.4.4 I noticed that melf does not seem to support GHC 9.4.4 yet. This caused my little Haskell project to stop building without `--allow-newer`. However, it seems that melf works entirely fine as is after updating the version constraints of `template-haskell` and `lens` (which I did in this PR).

Would you consider merging this and creating a new release?