### PR TITLE
Widden template-haskell version constraint to support GHC 9.8

### DIFF
--- a/melf.cabal
+++ b/melf.cabal
@@ -18,7 +18,7 @@ license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
 tested-with:
-    GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.7, GHC == 9.4.4, GHC == 9.6.1
+    GHC == 8.8.4, GHC == 8.10.7, GHC == 9.0.2, GHC == 9.2.7, GHC == 9.4.4, GHC == 9.6.1, GHC == 9.8.2
 extra-doc-files:
     ChangeLog.md
     README.md
@@ -78,7 +78,7 @@ library
     , lens >=5.0.1 && <5.3
     , mtl >=2.2.2 && <2.4
     , prettyprinter >=1.7.0 && <1.8
-    , template-haskell >=2.15 && <2.21
+    , template-haskell >=2.15 && <2.22
   default-language: Haskell2010
 
 executable hobjdump


### PR DESCRIPTION
template-haskell prior to version 2.21 does not support GHC 9.8, widening the version constraint to support version 2.21 makes melf compatible with GHC 9.8.